### PR TITLE
Cope with default format=None in fastaWriter

### DIFF
--- a/galaxy_utils/sequence/fasta.py
+++ b/galaxy_utils/sequence/fasta.py
@@ -121,9 +121,9 @@ class fastaWriter(object):
     def __init__(self, fh=None, format=None, path=None):
         if fh is None:
             assert path is not None
-            if format.endswith(".gz"):
+            if format and format.endswith(".gz"):
                 fh = gzip.open(path, "wt")
-            elif format.endswith(".bz2"):
+            elif format and format.endswith(".bz2"):
                 if six.PY2:
                     fh = bz2.BZ2File(path, mode="w")
                 else:
@@ -131,9 +131,9 @@ class fastaWriter(object):
             else:
                 fh = open(path, "wt")
         else:
-            if format.endswith(".gz"):
+            if format and format.endswith(".gz"):
                 fh = gzip.GzipFile(fileobj=fh)
-            elif format.endswith(".bz2"):
+            elif format and format.endswith(".bz2"):
                 raise Exception("bz2 formats do not support file handle inputs")
         self.file = fh
 

--- a/galaxy_utils/sequence/fastq.py
+++ b/galaxy_utils/sequence/fastq.py
@@ -747,7 +747,7 @@ class fastqWriter(object):
         else:
             if format and format.endswith(".gz"):
                 fh = gzip.GzipFile(fileobj=fh)
-            elif format.endswith(".bz2"):
+            elif format and format.endswith(".bz2"):
                 raise Exception("bz2 formats do not support file handle inputs")
         self.file = fh
         self.format = format

--- a/galaxy_utils/sequence/fastq.py
+++ b/galaxy_utils/sequence/fastq.py
@@ -735,9 +735,9 @@ class fastqWriter(object):
     def __init__(self, fh=None, format=None, force_quality_encoding=None, path=None):
         if fh is None:
             assert path is not None
-            if format.endswith(".gz"):
+            if format and format.endswith(".gz"):
                 fh = gzip.open(path, "wt")
-            elif format.endswith(".bz2"):
+            elif format and format.endswith(".bz2"):
                 if six.PY2:
                     fh = bz2.BZ2File(path, mode="w")
                 else:
@@ -745,7 +745,7 @@ class fastqWriter(object):
             else:
                 fh = open(path, "wt")
         else:
-            if format.endswith(".gz"):
+            if format and format.endswith(".gz"):
                 fh = gzip.GzipFile(fileobj=fh)
             elif format.endswith(".bz2"):
                 raise Exception("bz2 formats do not support file handle inputs")


### PR DESCRIPTION
Changes in #14 broke the use case of calling fastaWriter with the default value ``format=None``,

e.g.
https://travis-ci.org/peterjc/pico_galaxy/builds/399214302
https://github.com/peterjc/pico_galaxy/blob/f33111c359e931dbbad6a6d7a747183ed1676798/tools/seq_rename/seq_rename.py#L136