### PR TITLE
Prevent StopIteration from raising RuntimeError

### DIFF
--- a/galaxy_utils/sequence/fasta.py
+++ b/galaxy_utils/sequence/fasta.py
@@ -54,7 +54,11 @@ class fastaReader(Iterator):
 
     def __iter__(self):
         while True:
-            yield next(self)
+            try:
+                yield next(self)
+            except StopIteration:
+                # Catch exception and return normally
+                return
 
 
 class fastaNamedReader(object):

--- a/galaxy_utils/sequence/fastq.py
+++ b/galaxy_utils/sequence/fastq.py
@@ -613,7 +613,11 @@ class fastqReader(Iterator):
 
     def __iter__(self):
         while True:
-            yield next(self)
+            try:
+                yield next(self)
+            except StopIteration:
+                # Catch exception and return normally
+                return
 
 
 class ReadlineCountFile(object):


### PR DESCRIPTION
See #19 (PEP 479 enabled under Python 3.7; causes RuntimeError in
fastq, fasta).