### PR TITLE
Fix inconsistent identifier option for fastq_groomer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,3 @@ tool_test_output*
 docs/_build
 
 .venv
-
-# ctags file
-tags

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ tool_test_output*
 docs/_build
 
 .venv
+
+# ctags file
+tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python: 2.7
 env:
   - TOX_ENV=py27-lint
-  - TOX_ENV=py34-lint
+  - TOX_ENV=py35-lint
   - TOX_ENV=py27-lint-readme
   - TOX_ENV=py27
-  - TOX_ENV=py34
+  - TOX_ENV=py35
   - TOX_ENV=py27-lint-docstrings
   - TOX_ENV=tool-tests
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ flake8: ## check style using flake8 for current Python (faster than lint)
 	$(IN_VENV) flake8 $(SOURCE_DIR)  $(TEST_DIR)
 
 lint: ## check style using tox and flake8 for Python 2 and Python 3
-	$(IN_VENV) tox -e py27-lint && tox -e py34-lint
+	$(IN_VENV) tox -e py27-lint && tox -e py35-lint
 
 lint-readme: ## check README formatting for PyPI
 	$(IN_VENV) python setup.py check -r -s

--- a/galaxy_utils/sequence/scripts/fastq_combiner.py
+++ b/galaxy_utils/sequence/scripts/fastq_combiner.py
@@ -34,7 +34,6 @@ def main():
     elif qual_type == 'qualillumina':
         format = 'illumina'
 
-    out = fastqWriter(path=output_filename, format=format, force_quality_encoding=force_quality_encoding)
     if qual_filename == 'None':
         qual_input = fastqFakeFastaScoreReader(format, quality_encoding=force_quality_encoding)
     else:
@@ -43,14 +42,17 @@ def main():
     fastq_combiner = fastqCombiner(format)
     i = None
     skip_count = 0
-    for i, sequence in enumerate(fastaReader(open(fasta_filename, 'rt'))):
-        quality = qual_input.get(sequence)
-        if quality:
-            fastq_read = fastq_combiner.combine(sequence, quality)
-            out.write(fastq_read)
-        else:
-            skip_count += 1
-    out.close()
+
+    writer = fastqWriter(path=output_filename, format=format, force_quality_encoding=force_quality_encoding)
+    with writer:
+        for i, sequence in enumerate(fastaReader(open(fasta_filename, 'rt'))):
+            quality = qual_input.get(sequence)
+            if quality:
+                fastq_read = fastq_combiner.combine(sequence, quality)
+                writer.write(fastq_read)
+            else:
+                skip_count += 1
+
     if i is None:
         print("Your file contains no valid FASTA sequences.")
     else:

--- a/galaxy_utils/sequence/scripts/fastq_filter.py
+++ b/galaxy_utils/sequence/scripts/fastq_filter.py
@@ -30,19 +30,21 @@ def main():
     os.mkdir(additional_files_path)
     shutil.copy(script_filename, os.path.join(additional_files_path, 'debug.txt'))
 
-    # Dan, Others: Can we simply drop the "format=input_type" here since it is specified in reader.
-    # This optimization would cut runtime roughly in half (for my test case anyway). -John
-    out = fastqWriter(path=output_filename, format=input_type)
-
     i = None
     reads_kept = 0
     execfile(script_filename, globals())
-    for i, fastq_read in enumerate(fastqReader(path=input_filename, format=input_type)):
-        ret_val = fastq_read_pass_filter(fastq_read)  # fastq_read_pass_filter defined in script_filename  # NOQA
-        if ret_val:
-            out.write(fastq_read)
-            reads_kept += 1
-    out.close()
+
+    # Dan, Others: Can we simply drop the "format=input_type" here since it is specified in reader.
+    # This optimization would cut runtime roughly in half (for my test case anyway). -John
+    writer = fastqWriter(path=output_filename, format=input_type)
+    reader = fastqReader(path=input_filename, format=input_type)
+    with writer, reader:
+        for i, fastq_read in enumerate(reader):
+            ret_val = fastq_read_pass_filter(fastq_read)  # fastq_read_pass_filter defined in script_filename  # NOQA
+            if ret_val:
+                writer.write(fastq_read)
+                reads_kept += 1
+
     if i is None:
         print("Your file contains no valid fastq reads.")
     else:

--- a/galaxy_utils/sequence/scripts/fastq_groomer.py
+++ b/galaxy_utils/sequence/scripts/fastq_groomer.py
@@ -13,7 +13,8 @@ from galaxy_utils.sequence.fastq import (
 
 class Groomer():
 
-    def __init__(self):
+    def __init__(self, file_handle=None):
+        self.file_handle = file_handle
         args = self._get_args()
         self.input_filename = args.input_filename
         self.input_type = args.input_type
@@ -25,12 +26,6 @@ class Groomer():
 
         if self.force_quality_encoding == 'None':
             self.force_quality_encoding = None
-
-        self.file_handle = None
-
-    def set_file_handle(self, fh):
-        # required for testing (test file closed on error)
-        self.file_handle = fh
 
     def run(self):
         aggregator = fastqAggregator()

--- a/galaxy_utils/sequence/scripts/fastq_groomer.py
+++ b/galaxy_utils/sequence/scripts/fastq_groomer.py
@@ -13,60 +13,82 @@ from galaxy_utils.sequence.fastq import (
 
 class Groomer():
 
-    def run(self):
+    def __init__(self):
         args = self._get_args()
-        input_filename = args.input_filename
-        input_type = args.input_type
-        output_filename = args.output_filename
-        output_type = args.output_type
-        force_quality_encoding = args.force_quality_encoding
-        summarize_input = args.summarize_input == 'summarize_input'
-        fix_id = args.fix_id
-        if force_quality_encoding == 'None':
-            force_quality_encoding = None
+        self.input_filename = args.input_filename
+        self.input_type = args.input_type
+        self.output_filename = args.output_filename
+        self.output_type = args.output_type
+        self.force_quality_encoding = args.force_quality_encoding
+        self.summarize_input = args.summarize_input == 'summarize_input'
+        self.fix_id = args.fix_id
 
+        if self.force_quality_encoding == 'None':
+            self.force_quality_encoding = None
+
+    def run(self):
         aggregator = fastqAggregator()
-        out = fastqWriter(path=output_filename, format=output_type, force_quality_encoding=force_quality_encoding)
-        read_count = None
-        if summarize_input:
+        out = fastqWriter(
+            path=self.output_filename, format=self.output_type,
+            force_quality_encoding=self.force_quality_encoding)
+        if self.summarize_input:
             reader_type = fastqVerboseErrorReader
         else:
             reader_type = fastqReader
-        reader = reader_type(path=input_filename, format=input_type, apply_galaxy_conventions=True, fix_id=fix_id)
+        reader = reader_type(
+            path=self.input_filename, format=self.input_type, apply_galaxy_conventions=True,
+            fix_id=self.fix_id)
+        read_count = None
 
         for read_count, fastq_read in enumerate(reader):
-            if summarize_input:
+            if self.summarize_input:
                 aggregator.consume_read(fastq_read)
             out.write(fastq_read)
         out.close()
 
-        self._print_output(read_count, input_type, output_type, summarize_input, aggregator)
+        self._print_output(read_count, aggregator)
 
-    def _print_output(self, read_count, input_type, output_type, summarize_input, aggregator):
+    def _print_output(self, read_count, aggregator):
         if read_count is not None:
-            print("Groomed %i %s reads into %s reads." % (read_count + 1, input_type, output_type))
-            if input_type != output_type and 'solexa' in [input_type, output_type]:
+            print("Groomed %i %s reads into %s reads." % (read_count + 1, self.input_type, self.output_type))
+            if self.input_type != self.output_type and 'solexa' in [self.input_type, self.output_type]:
                 print("Converted between Solexa and PHRED scores.")
-            if summarize_input:
-                print("Based upon quality and sequence, the input data is valid for: %s" % (", ".join(aggregator.get_valid_formats()) or "None"))
+            if self.summarize_input:
+                print(
+                    "Based upon quality and sequence, the input data is valid for: %s" %
+                    (", ".join(aggregator.get_valid_formats()) or "None"))
                 ascii_range = aggregator.get_ascii_range()
                 decimal_range = aggregator.get_decimal_range()
                 # print using repr, since \x00 (null) causes info truncation in galaxy when printed
-                print("Input ASCII range: %s(%i) - %s(%i)" % (repr(ascii_range[0]), ord(ascii_range[0]), repr(ascii_range[1]), ord(ascii_range[1])))
+                print(
+                    "Input ASCII range: %s(%i) - %s(%i)" %
+                    (repr(ascii_range[0]), ord(ascii_range[0]), repr(ascii_range[1]), ord(ascii_range[1])))
                 print("Input decimal range: %i - %i" % (decimal_range[0], decimal_range[1]))
         else:
             print("No valid FASTQ reads were provided.")
 
     def _get_args(self):
-        parser = argparse.ArgumentParser()
-        parser.add_argument('input_filename', help='file to groom')
-        parser.add_argument('input_type', help='input FASTQ quality scores type')
-        parser.add_argument('output_filename', help='groomed output file')
-        parser.add_argument('output_type', help='input FASTQ quality scores type')
-        parser.add_argument('force_quality_encoding', help='force quality score encoding')
-        parser.add_argument('summarize_input', help='summarize input data')
-        parser.add_argument('--fix_id', help='fix inconsistent identifiers', action='store_true')
-        return parser.parse_args()
+        types = ['solexa', 'illumina', 'sanger', 'cssanger']
+        type_choices = [t + ext for t in types for ext in ['', '.gz', '.bz2']]
+        fqe_choices = ['None', 'ascii', 'decimal']
+        si_choices = ['summarize_input', 'dont_summarize_input']  # Should be yes/no (leave as is for now)
+
+        p = argparse.ArgumentParser()
+        p.add_argument('input_filename', help='file to groom')
+        p.add_argument('input_type', choices=type_choices, help='input FASTQ quality scores type')
+        p.add_argument('output_filename', help='groomed output file')
+        p.add_argument('output_type', choices=type_choices, help='input FASTQ quality scores type')
+        p.add_argument('force_quality_encoding', choices=fqe_choices, help='force quality score encoding')
+        p.add_argument('summarize_input', choices=si_choices, help='summarize input data')
+
+        fi_group = p.add_mutually_exclusive_group()
+        fi_group.add_argument(
+            '--fix-id', dest='fix_id', action='store_true', help='fix inconsistent identifiers')
+        fi_group.add_argument(
+            '--no-fix-id', dest='fix_id', action='store_false', help='do not fix inconsistent identifiers')
+        p.set_defaults(fix_id=True)
+
+        return p.parse_args()
 
 
 def main():

--- a/galaxy_utils/sequence/scripts/fastq_groomer.py
+++ b/galaxy_utils/sequence/scripts/fastq_groomer.py
@@ -21,43 +21,51 @@ class Groomer():
         output_type = args.output_type
         force_quality_encoding = args.force_quality_encoding
         summarize_input = args.summarize_input == 'summarize_input'
-
+        fix_id = args.fix_id
         if force_quality_encoding == 'None':
             force_quality_encoding = None
-    
-        fix_id = False # fix inconsistent identifiers (SRA data dumps)
-        # This test is diabled for an intermediate commit that does not include the new fix_id option.
-        # It should be enabled (possibly, modified) in the following commit.
-        #if len(sys.argv) > 7:
-        #    fix_id = sys.argv[7] == 'fix_id'
-    
+
         aggregator = fastqAggregator()
-        out = fastqWriter(path=output_filename, format=output_type, force_quality_encoding=force_quality_encoding)
+        out = fastqWriter(
+            path=output_filename, format=output_type, 
+            force_quality_encoding=force_quality_encoding)
         read_count = None
         if summarize_input:
             reader_type = fastqVerboseErrorReader
         else:
             reader_type = fastqReader
-    
-        reader = reader_type(path=input_filename, format=input_type, apply_galaxy_conventions=True, fix_id=fix_id)
+        reader = reader_type(
+            path=input_filename, format=input_type, 
+            apply_galaxy_conventions=True, fix_id=fix_id)
+
         for read_count, fastq_read in enumerate(reader):
             if summarize_input:
                 aggregator.consume_read(fastq_read)
             out.write(fastq_read)
         out.close()
     
-        self._print_output(read_count, input_type, output_type, summarize_input, aggregator)
+        self._print_output(
+            read_count, input_type, output_type, summarize_input, aggregator)
     
-    def _print_output(self, read_count, input_type, output_type, summarize_input, aggregator):
+    def _print_output(
+            self, read_count, input_type, output_type, summarize_input, aggregator):
         if read_count is not None:
-           print("Groomed %i %s reads into %s reads." % (read_count + 1, input_type, output_type))
+           print(
+               "Groomed %i %s reads into %s reads." % 
+               (read_count + 1, input_type, output_type))
            if input_type != output_type and 'solexa' in [input_type, output_type]:
                print("Converted between Solexa and PHRED scores.")
            if summarize_input:
-               print("Based upon quality and sequence, the input data is valid for: %s" % (", ".join(aggregator.get_valid_formats()) or "None"))
+               print("Based upon quality and sequence, the input data is valid for: %s" 
+                     % (", ".join(aggregator.get_valid_formats()) or "None"))
                ascii_range = aggregator.get_ascii_range()
                decimal_range = aggregator.get_decimal_range()
-               print("Input ASCII range: %s(%i) - %s(%i)" % (repr(ascii_range[0]), ord(ascii_range[0]), repr(ascii_range[1]), ord(ascii_range[1])))  # print using repr, since \x00 (null) causes info truncation in galaxy when printed
+
+               # print using repr, since \x00 (null) causes info truncation 
+               #   in galaxy when printed
+               print("Input ASCII range: %s(%i) - %s(%i)" % (
+                     repr(ascii_range[0]), ord(ascii_range[0]), 
+                     repr(ascii_range[1]), ord(ascii_range[1])))  
                print("Input decimal range: %i - %i" % (decimal_range[0], decimal_range[1]))
         else:
            print("No valid FASTQ reads were provided.")
@@ -75,6 +83,7 @@ def _get_args():
     parser.add_argument('output_type', help='input FASTQ quality scores type')
     parser.add_argument('force_quality_encoding', help='force quality score encoding')
     parser.add_argument('summarize_input', help='summarize input data')
+    parser.add_argument('--fix_id', help='fix inconsistent identifiers', action='store_true')
     return parser.parse_args()
 
 

--- a/galaxy_utils/sequence/scripts/fastq_groomer.py
+++ b/galaxy_utils/sequence/scripts/fastq_groomer.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 
 import argparse
-import sys
 
 from galaxy_utils.sequence.fastq import (
     fastqAggregator,
@@ -14,7 +13,8 @@ from galaxy_utils.sequence.fastq import (
 
 class Groomer():
 
-    def run(self, args):
+    def run(self):
+        args = self._get_args()
         input_filename = args.input_filename
         input_type = args.input_type
         output_filename = args.output_filename
@@ -26,67 +26,52 @@ class Groomer():
             force_quality_encoding = None
 
         aggregator = fastqAggregator()
-        out = fastqWriter(
-            path=output_filename, format=output_type, 
-            force_quality_encoding=force_quality_encoding)
+        out = fastqWriter(path=output_filename, format=output_type, force_quality_encoding=force_quality_encoding)
         read_count = None
         if summarize_input:
             reader_type = fastqVerboseErrorReader
         else:
             reader_type = fastqReader
-        reader = reader_type(
-            path=input_filename, format=input_type, 
-            apply_galaxy_conventions=True, fix_id=fix_id)
+        reader = reader_type(path=input_filename, format=input_type, apply_galaxy_conventions=True, fix_id=fix_id)
 
         for read_count, fastq_read in enumerate(reader):
             if summarize_input:
                 aggregator.consume_read(fastq_read)
             out.write(fastq_read)
         out.close()
-    
-        self._print_output(
-            read_count, input_type, output_type, summarize_input, aggregator)
-    
-    def _print_output(
-            self, read_count, input_type, output_type, summarize_input, aggregator):
-        if read_count is not None:
-           print(
-               "Groomed %i %s reads into %s reads." % 
-               (read_count + 1, input_type, output_type))
-           if input_type != output_type and 'solexa' in [input_type, output_type]:
-               print("Converted between Solexa and PHRED scores.")
-           if summarize_input:
-               print("Based upon quality and sequence, the input data is valid for: %s" 
-                     % (", ".join(aggregator.get_valid_formats()) or "None"))
-               ascii_range = aggregator.get_ascii_range()
-               decimal_range = aggregator.get_decimal_range()
 
-               # print using repr, since \x00 (null) causes info truncation 
-               #   in galaxy when printed
-               print("Input ASCII range: %s(%i) - %s(%i)" % (
-                     repr(ascii_range[0]), ord(ascii_range[0]), 
-                     repr(ascii_range[1]), ord(ascii_range[1])))  
-               print("Input decimal range: %i - %i" % (decimal_range[0], decimal_range[1]))
+        self._print_output(read_count, input_type, output_type, summarize_input, aggregator)
+
+    def _print_output(self, read_count, input_type, output_type, summarize_input, aggregator):
+        if read_count is not None:
+            print("Groomed %i %s reads into %s reads." % (read_count + 1, input_type, output_type))
+            if input_type != output_type and 'solexa' in [input_type, output_type]:
+                print("Converted between Solexa and PHRED scores.")
+            if summarize_input:
+                print("Based upon quality and sequence, the input data is valid for: %s" % (", ".join(aggregator.get_valid_formats()) or "None"))
+                ascii_range = aggregator.get_ascii_range()
+                decimal_range = aggregator.get_decimal_range()
+                # print using repr, since \x00 (null) causes info truncation in galaxy when printed
+                print("Input ASCII range: %s(%i) - %s(%i)" % (repr(ascii_range[0]), ord(ascii_range[0]), repr(ascii_range[1]), ord(ascii_range[1])))
+                print("Input decimal range: %i - %i" % (decimal_range[0], decimal_range[1]))
         else:
-           print("No valid FASTQ reads were provided.")
+            print("No valid FASTQ reads were provided.")
+
+    def _get_args(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('input_filename', help='file to groom')
+        parser.add_argument('input_type', help='input FASTQ quality scores type')
+        parser.add_argument('output_filename', help='groomed output file')
+        parser.add_argument('output_type', help='input FASTQ quality scores type')
+        parser.add_argument('force_quality_encoding', help='force quality score encoding')
+        parser.add_argument('summarize_input', help='summarize input data')
+        parser.add_argument('--fix_id', help='fix inconsistent identifiers', action='store_true')
+        return parser.parse_args()
 
 
 def main():
-    Groomer().run(_get_args())
-
-
-def _get_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('input_filename', help='file to groom')
-    parser.add_argument('input_type', help='input FASTQ quality scores type')
-    parser.add_argument('output_filename', help='groomed output file')
-    parser.add_argument('output_type', help='input FASTQ quality scores type')
-    parser.add_argument('force_quality_encoding', help='force quality score encoding')
-    parser.add_argument('summarize_input', help='summarize input data')
-    parser.add_argument('--fix_id', help='fix inconsistent identifiers', action='store_true')
-    return parser.parse_args()
+    Groomer().run()
 
 
 if __name__ == "__main__":
     main()
-

--- a/galaxy_utils/sequence/scripts/fastq_groomer.py
+++ b/galaxy_utils/sequence/scripts/fastq_groomer.py
@@ -26,6 +26,12 @@ class Groomer():
         if self.force_quality_encoding == 'None':
             self.force_quality_encoding = None
 
+        self.file_handle = None
+
+    def set_file_handle(self, fh):
+        # required for testing (test file closed on error)
+        self.file_handle = fh
+
     def run(self):
         aggregator = fastqAggregator()
         out = fastqWriter(
@@ -36,8 +42,8 @@ class Groomer():
         else:
             reader_type = fastqReader
         reader = reader_type(
-            path=self.input_filename, format=self.input_type, apply_galaxy_conventions=True,
-            fix_id=self.fix_id)
+            fh=self.file_handle, path=self.input_filename, format=self.input_type,
+            apply_galaxy_conventions=True, fix_id=self.fix_id)
         read_count = None
 
         for read_count, fastq_read in enumerate(reader):

--- a/galaxy_utils/sequence/scripts/fastq_groomer.py
+++ b/galaxy_utils/sequence/scripts/fastq_groomer.py
@@ -1,6 +1,7 @@
 # Dan Blankenberg
 from __future__ import print_function
 
+import argparse
 import sys
 
 from galaxy_utils.sequence.fastq import (
@@ -11,52 +12,72 @@ from galaxy_utils.sequence.fastq import (
 )
 
 
-def main():
-    input_filename = sys.argv[1]
-    input_type = sys.argv[2]
-    output_filename = sys.argv[3]
-    output_type = sys.argv[4]
-    force_quality_encoding = sys.argv[5]
-    summarize_input = sys.argv[6] == 'summarize_input'
-    if force_quality_encoding == 'None':
-        force_quality_encoding = None
+class Groomer():
 
-    fix_id = False # fix inconsistent identifiers (SRA data dumps)
-    if len(sys.argv) > 7:
-        fix_id = sys.argv[7] == 'fix_id'
+    def run(self, args):
+        input_filename = args.input_filename
+        input_type = args.input_type
+        output_filename = args.output_filename
+        output_type = args.output_type
+        force_quality_encoding = args.force_quality_encoding
+        summarize_input = args.summarize_input == 'summarize_input'
 
-    aggregator = fastqAggregator()
-    out = fastqWriter(path=output_filename, format=output_type, force_quality_encoding=force_quality_encoding)
-    read_count = None
-    if summarize_input:
-        reader_type = fastqVerboseErrorReader
-    else:
-        reader_type = fastqReader
-
-    reader = reader_type(path=input_filename, format=input_type, apply_galaxy_conventions=True, fix_id=fix_id)
-    for read_count, fastq_read in enumerate(reader):
+        if force_quality_encoding == 'None':
+            force_quality_encoding = None
+    
+        fix_id = False # fix inconsistent identifiers (SRA data dumps)
+        # This test is diabled for an intermediate commit that does not include the new fix_id option.
+        # It should be enabled (possibly, modified) in the following commit.
+        #if len(sys.argv) > 7:
+        #    fix_id = sys.argv[7] == 'fix_id'
+    
+        aggregator = fastqAggregator()
+        out = fastqWriter(path=output_filename, format=output_type, force_quality_encoding=force_quality_encoding)
+        read_count = None
         if summarize_input:
-            aggregator.consume_read(fastq_read)
-        out.write(fastq_read)
-    out.close()
+            reader_type = fastqVerboseErrorReader
+        else:
+            reader_type = fastqReader
+    
+        reader = reader_type(path=input_filename, format=input_type, apply_galaxy_conventions=True, fix_id=fix_id)
+        for read_count, fastq_read in enumerate(reader):
+            if summarize_input:
+                aggregator.consume_read(fastq_read)
+            out.write(fastq_read)
+        out.close()
+    
+        self._print_output(read_count, input_type, output_type, summarize_input, aggregator)
+    
+    def _print_output(self, read_count, input_type, output_type, summarize_input, aggregator):
+        if read_count is not None:
+           print("Groomed %i %s reads into %s reads." % (read_count + 1, input_type, output_type))
+           if input_type != output_type and 'solexa' in [input_type, output_type]:
+               print("Converted between Solexa and PHRED scores.")
+           if summarize_input:
+               print("Based upon quality and sequence, the input data is valid for: %s" % (", ".join(aggregator.get_valid_formats()) or "None"))
+               ascii_range = aggregator.get_ascii_range()
+               decimal_range = aggregator.get_decimal_range()
+               print("Input ASCII range: %s(%i) - %s(%i)" % (repr(ascii_range[0]), ord(ascii_range[0]), repr(ascii_range[1]), ord(ascii_range[1])))  # print using repr, since \x00 (null) causes info truncation in galaxy when printed
+               print("Input decimal range: %i - %i" % (decimal_range[0], decimal_range[1]))
+        else:
+           print("No valid FASTQ reads were provided.")
 
-    _print_output(read_count, input_type, output_type, summarize_input, aggregator)
 
-   
-def _print_output(read_count, input_type, output_type, summarize_input, aggregator):
-    if read_count is not None:
-       print("Groomed %i %s reads into %s reads." % (read_count + 1, input_type, output_type))
-       if input_type != output_type and 'solexa' in [input_type, output_type]:
-           print("Converted between Solexa and PHRED scores.")
-       if summarize_input:
-           print("Based upon quality and sequence, the input data is valid for: %s" % (", ".join(aggregator.get_valid_formats()) or "None"))
-           ascii_range = aggregator.get_ascii_range()
-           decimal_range = aggregator.get_decimal_range()
-           print("Input ASCII range: %s(%i) - %s(%i)" % (repr(ascii_range[0]), ord(ascii_range[0]), repr(ascii_range[1]), ord(ascii_range[1])))  # print using repr, since \x00 (null) causes info truncation in galaxy when printed
-           print("Input decimal range: %i - %i" % (decimal_range[0], decimal_range[1]))
-    else:
-       print("No valid FASTQ reads were provided.")
+def main():
+    Groomer().run(_get_args())
+
+
+def _get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input_filename', help='file to groom')
+    parser.add_argument('input_type', help='input FASTQ quality scores type')
+    parser.add_argument('output_filename', help='groomed output file')
+    parser.add_argument('output_type', help='input FASTQ quality scores type')
+    parser.add_argument('force_quality_encoding', help='force quality score encoding')
+    parser.add_argument('summarize_input', help='summarize input data')
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
     main()
+

--- a/galaxy_utils/sequence/scripts/fastq_manipulation.py
+++ b/galaxy_utils/sequence/scripts/fastq_manipulation.py
@@ -23,18 +23,19 @@ def main():
     shutil.copy(script_filename, os.path.join(additional_files_path, 'debug.txt'))
 
     fastq_manipulator = imp.load_module('fastq_manipulator', open(script_filename), script_filename, ('', 'r', imp.PY_SOURCE))
-
-    out = fastqWriter(path=output_filename, format=input_type)
-
     i = None
     reads_manipulated = 0
-    for i, fastq_read in enumerate(fastqReader(path=input_filename, format=input_type)):
-        new_read = fastq_manipulator.match_and_manipulate_read(fastq_read)
-        if new_read:
-            out.write(new_read)
-        if new_read != fastq_read:
-            reads_manipulated += 1
-    out.close()
+
+    writer = fastqWriter(path=output_filename, format=input_type)
+    reader = fastqReader(path=input_filename, format=input_type)
+    with writer, reader:
+        for i, fastq_read in enumerate(reader):
+            new_read = fastq_manipulator.match_and_manipulate_read(fastq_read)
+            if new_read:
+                writer.write(new_read)
+            if new_read != fastq_read:
+                reads_manipulated += 1
+
     if i is None:
         print("Your file contains no valid FASTQ reads.")
     else:

--- a/galaxy_utils/sequence/scripts/fastq_masker_by_quality.py
+++ b/galaxy_utils/sequence/scripts/fastq_masker_by_quality.py
@@ -75,16 +75,18 @@ def main():
     else:
         base_masker = BaseReplacer(options.mask_character)
 
-    out = fastqWriter(path=args[1], format=options.format)
-
     num_reads = None
-    for num_reads, fastq_read in enumerate(fastqReader(path=args[0], format=options.format)):
-        sequence_list = list(fastq_read.sequence)
-        for i, quality_score in enumerate(fastq_read.get_decimal_quality_scores()):
-            if score_comparer(quality_score, options.quality_score):
-                sequence_list[i] = base_masker(sequence_list[i])
-        fastq_read.sequence = "".join(sequence_list)
-        out.write(fastq_read)
+
+    writer = fastqWriter(path=args[1], format=options.format)
+    reader = fastqReader(path=args[0], format=options.format)
+    with writer, reader:
+        for num_reads, fastq_read in enumerate(reader):
+            sequence_list = list(fastq_read.sequence)
+            for i, quality_score in enumerate(fastq_read.get_decimal_quality_scores()):
+                if score_comparer(quality_score, options.quality_score):
+                    sequence_list[i] = base_masker(sequence_list[i])
+            fastq_read.sequence = "".join(sequence_list)
+            writer.write(fastq_read)
 
     if num_reads is not None:
         print("Processed %i %s reads." % (num_reads + 1, options.format))

--- a/galaxy_utils/sequence/scripts/fastq_paired_end_deinterlacer.py
+++ b/galaxy_utils/sequence/scripts/fastq_paired_end_deinterlacer.py
@@ -1,7 +1,6 @@
 # Florent Angly
 from __future__ import print_function
 
-import argparse
 import sys
 
 from galaxy_utils.sequence.fastq import (
@@ -12,81 +11,64 @@ from galaxy_utils.sequence.fastq import (
 )
 
 
-class Deinterlacer():
-
-    def run(self, input_filename, type, mate1_filename, mate2_filename, 
-            single1_filename, single2_filename):
-
-        # temporary fix (note to self: refactor argument processing)
-        if not type: 
-            type = 'sanger'
-
-        input = fastqNamedReader(path=input_filename, format=type)
-        mate1_out = fastqWriter(path=mate1_filename, format=type)
-        mate2_out = fastqWriter(path=mate2_filename, format=type)
-        single1_out = fastqWriter(path=single1_filename, format=type)
-        single2_out = fastqWriter(path=single2_filename, format=type)
-        joiner = fastqJoiner(type)
-    
-        i = None
-        skip_count = 0
-        found = {}
-        for i, read in enumerate(fastqReader(path=input_filename, format=type)):
-    
-            if read.identifier in found:
-                del found[read.identifier]
-                continue
-    
-            mate1 = input.get(read.identifier)
-    
-            mate2 = input.get(joiner.get_paired_identifier(mate1))
-    
-            if mate2:
-                # This is a mate pair
-                found[mate2.identifier] = None
-                if joiner.is_first_mate(mate1):
-                    mate1_out.write(mate1)
-                    mate2_out.write(mate2)
-                else:
-                    mate1_out.write(mate2)
-                    mate2_out.write(mate1)
-            else:
-                # This is a single
-                skip_count += 1
-                if joiner.is_first_mate(mate1):
-                    single1_out.write(mate1)
-                else:
-                    single2_out.write(mate1)
-    
-        if i is None:
-            print("Your input file contained no valid FASTQ sequences.")
-        else:
-            if skip_count:
-                print('There were %i reads with no mate.' % skip_count)
-            print('De-interlaced %s pairs of sequences.' % ((i - skip_count + 1) / 2))
-    
-        input.close()
-        mate1_out.close()
-        mate2_out.close()
-        single1_out.close()
-        single2_out.close()
-
-
 def main():
-    args = _arg_parser().parse_args()
-    Deinterlacer().run(args.input_filename, args.type, args.mate1_filename, 
-        args.mate2_filename, args.single1_filename, args.single2_filename)
+    input_filename = sys.argv[1]
+    input_type = sys.argv[2] or 'sanger'
+    mate1_filename = sys.argv[3]
+    mate2_filename = sys.argv[4]
+    single1_filename = sys.argv[5]
+    single2_filename = sys.argv[6]
 
+    type = input_type
+    input = fastqNamedReader(path=input_filename, format=type)
+    mate1_out = fastqWriter(path=mate1_filename, format=type)
+    mate2_out = fastqWriter(path=mate2_filename, format=type)
+    single1_out = fastqWriter(path=single1_filename, format=type)
+    single2_out = fastqWriter(path=single2_filename, format=type)
+    joiner = fastqJoiner(type)
 
-def _arg_parser():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('input_filename')
-    parser.add_argument('type') 
-    parser.add_argument('mate1_filename')
-    parser.add_argument('mate2_filename')
-    parser.add_argument('single1_filename')
-    parser.add_argument('single2_filename')
-    return parser
+    i = None
+    skip_count = 0
+    found = {}
+    for i, read in enumerate(fastqReader(path=input_filename, format=type)):
+
+        if read.identifier in found:
+            del found[read.identifier]
+            continue
+
+        mate1 = input.get(read.identifier)
+
+        mate2 = input.get(joiner.get_paired_identifier(mate1))
+
+        if mate2:
+            # This is a mate pair
+            found[mate2.identifier] = None
+            if joiner.is_first_mate(mate1):
+                mate1_out.write(mate1)
+                mate2_out.write(mate2)
+            else:
+                mate1_out.write(mate2)
+                mate2_out.write(mate1)
+        else:
+            # This is a single
+            skip_count += 1
+            if joiner.is_first_mate(mate1):
+                single1_out.write(mate1)
+            else:
+                single2_out.write(mate1)
+
+    if i is None:
+        print("Your input file contained no valid FASTQ sequences.")
+    else:
+        if skip_count:
+            print('There were %i reads with no mate.' % skip_count)
+        print('De-interlaced %s pairs of sequences.' % ((i - skip_count + 1) / 2))
+
+    input.close()
+    mate1_out.close()
+    mate2_out.close()
+    single1_out.close()
+    single2_out.close()
 
 
 if __name__ == "__main__":

--- a/galaxy_utils/sequence/scripts/fastq_paired_end_deinterlacer.py
+++ b/galaxy_utils/sequence/scripts/fastq_paired_end_deinterlacer.py
@@ -17,6 +17,10 @@ class Deinterlacer():
     def run(self, input_filename, type, mate1_filename, mate2_filename, 
             single1_filename, single2_filename):
 
+        # temporary fix (note to self: refactor argument processing)
+        if not type: 
+            type = 'sanger'
+
         input = fastqNamedReader(path=input_filename, format=type)
         mate1_out = fastqWriter(path=mate1_filename, format=type)
         mate2_out = fastqWriter(path=mate2_filename, format=type)

--- a/galaxy_utils/sequence/scripts/fastq_paired_end_deinterlacer.py
+++ b/galaxy_utils/sequence/scripts/fastq_paired_end_deinterlacer.py
@@ -1,6 +1,7 @@
 # Florent Angly
 from __future__ import print_function
 
+import argparse
 import sys
 
 from galaxy_utils.sequence.fastq import (
@@ -11,64 +12,77 @@ from galaxy_utils.sequence.fastq import (
 )
 
 
-def main():
-    input_filename = sys.argv[1]
-    input_type = sys.argv[2] or 'sanger'
-    mate1_filename = sys.argv[3]
-    mate2_filename = sys.argv[4]
-    single1_filename = sys.argv[5]
-    single2_filename = sys.argv[6]
+class Deinterlacer():
 
-    type = input_type
-    input = fastqNamedReader(path=input_filename, format=type)
-    mate1_out = fastqWriter(path=mate1_filename, format=type)
-    mate2_out = fastqWriter(path=mate2_filename, format=type)
-    single1_out = fastqWriter(path=single1_filename, format=type)
-    single2_out = fastqWriter(path=single2_filename, format=type)
-    joiner = fastqJoiner(type)
+    def run(self, input_filename, type, mate1_filename, mate2_filename, 
+            single1_filename, single2_filename):
 
-    i = None
-    skip_count = 0
-    found = {}
-    for i, read in enumerate(fastqReader(path=input_filename, format=type)):
-
-        if read.identifier in found:
-            del found[read.identifier]
-            continue
-
-        mate1 = input.get(read.identifier)
-
-        mate2 = input.get(joiner.get_paired_identifier(mate1))
-
-        if mate2:
-            # This is a mate pair
-            found[mate2.identifier] = None
-            if joiner.is_first_mate(mate1):
-                mate1_out.write(mate1)
-                mate2_out.write(mate2)
+        input = fastqNamedReader(path=input_filename, format=type)
+        mate1_out = fastqWriter(path=mate1_filename, format=type)
+        mate2_out = fastqWriter(path=mate2_filename, format=type)
+        single1_out = fastqWriter(path=single1_filename, format=type)
+        single2_out = fastqWriter(path=single2_filename, format=type)
+        joiner = fastqJoiner(type)
+    
+        i = None
+        skip_count = 0
+        found = {}
+        for i, read in enumerate(fastqReader(path=input_filename, format=type)):
+    
+            if read.identifier in found:
+                del found[read.identifier]
+                continue
+    
+            mate1 = input.get(read.identifier)
+    
+            mate2 = input.get(joiner.get_paired_identifier(mate1))
+    
+            if mate2:
+                # This is a mate pair
+                found[mate2.identifier] = None
+                if joiner.is_first_mate(mate1):
+                    mate1_out.write(mate1)
+                    mate2_out.write(mate2)
+                else:
+                    mate1_out.write(mate2)
+                    mate2_out.write(mate1)
             else:
-                mate1_out.write(mate2)
-                mate2_out.write(mate1)
+                # This is a single
+                skip_count += 1
+                if joiner.is_first_mate(mate1):
+                    single1_out.write(mate1)
+                else:
+                    single2_out.write(mate1)
+    
+        if i is None:
+            print("Your input file contained no valid FASTQ sequences.")
         else:
-            # This is a single
-            skip_count += 1
-            if joiner.is_first_mate(mate1):
-                single1_out.write(mate1)
-            else:
-                single2_out.write(mate1)
+            if skip_count:
+                print('There were %i reads with no mate.' % skip_count)
+            print('De-interlaced %s pairs of sequences.' % ((i - skip_count + 1) / 2))
+    
+        input.close()
+        mate1_out.close()
+        mate2_out.close()
+        single1_out.close()
+        single2_out.close()
 
-    if i is None:
-        print("Your input file contained no valid FASTQ sequences.")
-    else:
-        if skip_count:
-            print('There were %i reads with no mate.' % skip_count)
-        print('De-interlaced %s pairs of sequences.' % ((i - skip_count + 1) / 2))
 
-    input.close()
-    mate1_out.close()
-    mate2_out.close()
-    single1_out.close()
-    single2_out.close()
+def main():
+    args = _arg_parser().parse_args()
+    Deinterlacer().run(args.input_filename, args.type, args.mate1_filename, 
+        args.mate2_filename, args.single1_filename, args.single2_filename)
+
+
+def _arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input_filename')
+    parser.add_argument('type') 
+    parser.add_argument('mate1_filename')
+    parser.add_argument('mate2_filename')
+    parser.add_argument('single1_filename')
+    parser.add_argument('single2_filename')
+    return parser
 
 
 if __name__ == "__main__":

--- a/galaxy_utils/sequence/scripts/fastq_paired_end_deinterlacer.py
+++ b/galaxy_utils/sequence/scripts/fastq_paired_end_deinterlacer.py
@@ -29,20 +29,20 @@ def main():
     mate2_out = fastqWriter(path=mate2_filename, format=type)
     single1_out = fastqWriter(path=single1_filename, format=type)
     single2_out = fastqWriter(path=single2_filename, format=type)
-    input = fastqNamedReader(path=input_filename, format=type)
-    reader = fastqReader(path=input_filename, format=type)
+    reader1 = fastqNamedReader(path=input_filename, format=type)
+    reader2 = fastqReader(path=input_filename, format=type)
 
-    with mate1_out, mate2_out, single1_out, single2_out, input, reader:
+    with mate1_out, mate2_out, single1_out, single2_out, reader1, reader2:
 
-        for i, read in enumerate(reader):
+        for i, read in enumerate(reader2):
 
             if read.identifier in found:
                 del found[read.identifier]
                 continue
 
-            mate1 = input.get(read.identifier)
+            mate1 = reader1.get(read.identifier)
 
-            mate2 = input.get(joiner.get_paired_identifier(mate1))
+            mate2 = reader1.get(joiner.get_paired_identifier(mate1))
 
             if mate2:
                 # This is a mate pair
@@ -67,8 +67,6 @@ def main():
         if skip_count:
             print('There were %i reads with no mate.' % skip_count)
         print('De-interlaced %s pairs of sequences.' % ((i - skip_count + 1) / 2))
-
-    input.close()
 
 
 if __name__ == "__main__":

--- a/galaxy_utils/sequence/scripts/fastq_paired_end_interlacer.py
+++ b/galaxy_utils/sequence/scripts/fastq_paired_end_interlacer.py
@@ -25,43 +25,43 @@ def main():
 
     type = mate1_type
     joiner = fastqJoiner(type)
-    out_pairs = fastqWriter(path=outfile_pairs, format=type)
-    out_singles = fastqWriter(path=outfile_singles, format=type)
 
-    # Pairs + singles present in mate1
     nof_singles = 0
     nof_pairs = 0
-    mate2_input = fastqNamedReader(path=mate2_filename, format=type)
     i = None
-    for i, mate1 in enumerate(fastqReader(path=mate1_filename, format=type)):
-        mate2 = mate2_input.get(joiner.get_paired_identifier(mate1))
-        if mate2:
-            out_pairs.write(mate1)
-            out_pairs.write(mate2)
-            nof_pairs += 1
-        else:
-            out_singles.write(mate1)
-            nof_singles += 1
-
-    # Singles present in mate2
-    mate1_input = fastqNamedReader(path=mate1_filename, format=type)
     j = None
-    for j, mate2 in enumerate(fastqReader(path=mate2_filename, format=type)):
-        mate1 = mate1_input.get(joiner.get_paired_identifier(mate2))
-        if not mate1:
-            out_singles.write(mate2)
-            nof_singles += 1
+
+    out_pairs = fastqWriter(path=outfile_pairs, format=type)
+    out_singles = fastqWriter(path=outfile_singles, format=type)
+    mate2_input = fastqNamedReader(path=mate2_filename, format=type)
+    mate1_input = fastqNamedReader(path=mate1_filename, format=type)
+    reader1 = fastqReader(path=mate1_filename, format=type)
+    reader2 = fastqReader(path=mate2_filename, format=type)
+
+    with out_pairs, out_singles, mate2_input, mate1_input, reader1, reader2:
+        # Pairs + singles present in mate1
+        for i, mate1 in enumerate(reader1):
+            mate2 = mate2_input.get(joiner.get_paired_identifier(mate1))
+            if mate2:
+                out_pairs.write(mate1)
+                out_pairs.write(mate2)
+                nof_pairs += 1
+            else:
+                out_singles.write(mate1)
+                nof_singles += 1
+
+        # Singles present in mate2
+        for j, mate2 in enumerate(reader2):
+            mate1 = mate1_input.get(joiner.get_paired_identifier(mate2))
+            if not mate1:
+                out_singles.write(mate2)
+                nof_singles += 1
 
     if (i is None) and (j is None):
         print("Your input files contained no valid FASTQ sequences.")
     else:
         print('There were %s single reads.' % (nof_singles))
         print('Interlaced %s pairs of sequences.' % (nof_pairs))
-
-    mate1_input.close()
-    mate2_input.close()
-    out_pairs.close()
-    out_singles.close()
 
 
 if __name__ == "__main__":

--- a/galaxy_utils/sequence/scripts/fastq_paired_end_splitter.py
+++ b/galaxy_utils/sequence/scripts/fastq_paired_end_splitter.py
@@ -18,20 +18,21 @@ def main():
     output2_filename = sys.argv[4]
 
     splitter = fastqSplitter()
-    out1 = fastqWriter(path=output1_filename, format=input_type)
-    out2 = fastqWriter(path=output2_filename, format=input_type)
-
     i = None
     skip_count = 0
-    for i, fastq_read in enumerate(fastqReader(path=input_filename, format=input_type)):
-        read1, read2 = splitter.split(fastq_read)
-        if read1 and read2:
-            out1.write(read1)
-            out2.write(read2)
-        else:
-            skip_count += 1
-    out1.close()
-    out2.close()
+
+    writer1 = fastqWriter(path=output1_filename, format=input_type)
+    writer2 = fastqWriter(path=output2_filename, format=input_type)
+    reader = fastqReader(path=input_filename, format=input_type)
+    with writer1, writer2, reader:
+        for i, fastq_read in enumerate(reader):
+            read1, read2 = splitter.split(fastq_read)
+            if read1 and read2:
+                writer1.write(read1)
+                writer2.write(read2)
+            else:
+                skip_count += 1
+
     if i is None:
         print("Your file contains no valid FASTQ reads.")
     else:

--- a/galaxy_utils/sequence/scripts/fastq_stats.py
+++ b/galaxy_utils/sequence/scripts/fastq_stats.py
@@ -22,8 +22,9 @@ def main():
     aggregator = fastqAggregator()
     num_reads = None
     fastq_read = None
-    for num_reads, fastq_read in enumerate(fastqReader(path=input_filename, format=input_type)):
-        aggregator.consume_read(fastq_read)
+    with fastqReader(path=input_filename, format=input_type) as reader:
+        for num_reads, fastq_read in enumerate(reader):
+            aggregator.consume_read(fastq_read)
     out = open(output_filename, 'w')
     valid_nucleotides = VALID_NUCLEOTIDES
     if fastq_read:

--- a/galaxy_utils/sequence/scripts/fastq_to_fasta.py
+++ b/galaxy_utils/sequence/scripts/fastq_to_fasta.py
@@ -16,9 +16,13 @@ def main():
     num_reads = None
     fastq_read = None
     out = fastaWriter(path=output_filename, format="fasta")
-    for num_reads, fastq_read in enumerate(fastqReader(path=input_filename, format=input_type)):
-        out.write(fastq_read)
-    out.close()
+
+    reader = fastqReader(path=input_filename, format=input_type)
+    with reader:
+        for num_reads, fastq_read in enumerate(reader):
+            out.write(fastq_read)
+        out.close()
+
     if num_reads is None:
         print("No valid FASTQ reads could be processed.")
     else:

--- a/galaxy_utils/sequence/scripts/fastq_to_tabular.py
+++ b/galaxy_utils/sequence/scripts/fastq_to_tabular.py
@@ -20,17 +20,19 @@ def main():
     num_reads = None
     fastq_read = None
     out = open(output_filename, 'wt')
-    if descr_split == 0:
-        # Don't divide the description into multiple columns
-        for num_reads, fastq_read in enumerate(fastqReader(path=input_filename, format=input_type)):
-            out.write("%s\t%s\t%s\n" % (fastq_read.identifier[1:].replace('\t', ' '), fastq_read.sequence.replace('\t', ' '), fastq_read.quality.replace('\t', ' ')))
-    else:
-        for num_reads, fastq_read in enumerate(fastqReader(path=input_filename, format=input_type)):
-            words = fastq_read.identifier[1:].replace('\t', ' ').split(None, descr_split)
-            # pad with empty columns if required
-            words += [""] * (descr_split - len(words))
-            out.write("%s\t%s\t%s\n" % ("\t".join(words), fastq_read.sequence.replace('\t', ' '), fastq_read.quality.replace('\t', ' ')))
-    out.close()
+
+    with fastqReader(path=input_filename, format=input_type) as reader:
+        if descr_split == 0:
+            # Don't divide the description into multiple columns
+            for num_reads, fastq_read in enumerate(reader):
+                out.write("%s\t%s\t%s\n" % (fastq_read.identifier[1:].replace('\t', ' '), fastq_read.sequence.replace('\t', ' '), fastq_read.quality.replace('\t', ' ')))
+        else:
+            for num_reads, fastq_read in enumerate(reader):
+                words = fastq_read.identifier[1:].replace('\t', ' ').split(None, descr_split)
+                # pad with empty columns if required
+                words += [""] * (descr_split - len(words))
+                out.write("%s\t%s\t%s\n" % ("\t".join(words), fastq_read.sequence.replace('\t', ' '), fastq_read.quality.replace('\t', ' ')))
+
     if num_reads is None:
         print("No valid FASTQ reads could be processed.")
     else:

--- a/tests/test_data/fastqreader_min_invalid-line3_fixed
+++ b/tests/test_data/fastqreader_min_invalid-line3_fixed
@@ -1,0 +1,8 @@
+@FAKE-1
+ACGTACGTAC
++
+!##$%&&()*
+@FAKE-2
+CATGCATGCA
++
+~}|{zyxwvu

--- a/tests/test_fastq.py
+++ b/tests/test_fastq.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from galaxy_utils.sequence.fastq import fastqReader, fastqFormatError
+from galaxy_utils.sequence.fastq import fastqFormatError, fastqReader
 
 TEST_DIR = os.path.dirname(__file__)
 TEST_DATA_DIR = os.path.join(TEST_DIR, 'test_data')
@@ -12,38 +12,39 @@ class FastqReaderTestCase(unittest.TestCase):
     def test_file_closed_on_completion(self):
         i_path = _data_path('fastqreader_min')
         fh = open(i_path)
-        reader = fastqReader(fh)
-        for _ in reader:
-            pass
+        with fastqReader(fh) as reader:
+            for _ in reader:
+                pass
 
         self.assertTrue(
-            fh.closed, 
+            fh.closed,
             'File should be closed after iteration compeletes')
 
     def test_file_closed_on_header_error(self):
         i_path = _data_path('fastqreader_min_invalid-header')
         fh = open(i_path)
-        reader = fastqReader(fh)
 
-        with self.assertRaises(fastqFormatError):
-            for _ in reader:
-                pass
+        with fastqReader(fh) as reader:
+            with self.assertRaises(fastqFormatError):
+                for _ in reader:
+                    pass
+
         self.assertTrue(
-            fh.closed, 
+            fh.closed,
             'File should be closed if exception occurs due to invalid header')
 
     def test_invalid_header(self):
         i_path = _data_path('fastqreader_min_invalid-header')
-        reader = fastqReader(path=i_path)
 
-        with self.assertRaises(fastqFormatError):
-            for _ in reader:
-                pass
+        with fastqReader(path=i_path) as reader:
+            with self.assertRaises(fastqFormatError):
+                for _ in reader:
+                    pass
 
     def test_read_header(self):
         i_path = _data_path('fastqreader_min')
-        reader = fastqReader(path=i_path)
-        rvals = [rval for rval in reader]
+        with fastqReader(path=i_path) as reader:
+            rvals = [rval for rval in reader]
 
         expected_reads = 2
         expected_headers = '@FAKE-1', '@FAKE-2'
@@ -54,8 +55,8 @@ class FastqReaderTestCase(unittest.TestCase):
 
     def test_read_sequence(self):
         i_path = _data_path('fastqreader_min')
-        reader = fastqReader(path=i_path)
-        rvals = [rval for rval in reader]
+        with fastqReader(path=i_path) as reader:
+            rvals = [rval for rval in reader]
 
         expected_reads = 2
         expected_seqs = 'ACGTACGTAC', 'CATGCATGCA'
@@ -66,8 +67,8 @@ class FastqReaderTestCase(unittest.TestCase):
 
     def test_read_sequence_multiline(self):
         i_path = _data_path('fastqreader_min-multiline')
-        reader = fastqReader(path=i_path)
-        rvals = [rval for rval in reader]
+        with fastqReader(path=i_path) as reader:
+            rvals = [rval for rval in reader]
 
         expected_reads = 2
         expected_seqs = 'ACGTACGTACGTACGTACGT', 'CATGCATGCATGCATGCATG'
@@ -78,8 +79,8 @@ class FastqReaderTestCase(unittest.TestCase):
 
     def test_read_qualityscores(self):
         i_path = _data_path('fastqreader_min')
-        reader = fastqReader(path=i_path)
-        rvals = [rval for rval in reader]
+        with fastqReader(path=i_path) as reader:
+            rvals = [rval for rval in reader]
 
         expected_reads = 2
         expected_scores = '!##$%&&()*', '~}|{zyxwvu'
@@ -90,8 +91,8 @@ class FastqReaderTestCase(unittest.TestCase):
 
     def test_read_qualityscores_multiline(self):
         i_path = _data_path('fastqreader_min-multiline')
-        reader = fastqReader(path=i_path)
-        rvals = [rval for rval in reader]
+        with fastqReader(path=i_path) as reader:
+            rvals = [rval for rval in reader]
 
         expected_reads = 2
         expected_scores = '!##$%&&()**,-./01234', '~}|{zyxwvutsrqponmlk'
@@ -103,12 +104,11 @@ class FastqReaderTestCase(unittest.TestCase):
     def test_read_qualityscores_edgecase_multiline(self):
         # Quality score input designed to confuse the parser
         i_path = _data_path('fastqreader_min-multiline-edgecase')
-        reader = fastqReader(path=i_path)
-        rvals = [rval for rval in reader]
+        with fastqReader(path=i_path) as reader:
+            rvals = [rval for rval in reader]
 
         expected_reads = 2
-        expected_scores = ('+##$%&&()*+##$%&&()*@,-./01234', 
-            '@}|{zyxwvu@}|{zyxwvu+srqponmlk')
+        expected_scores = ('+##$%&&()*+##$%&&()*@,-./01234', '@}|{zyxwvu@}|{zyxwvu+srqponmlk')
 
         self.assertEqual(expected_reads, len(rvals))
         self.assertEqual(expected_scores[0], rvals[0].quality)
@@ -117,8 +117,8 @@ class FastqReaderTestCase(unittest.TestCase):
     def test_read_line3(self):
         # Separate test case for line3 containing a copy of line1
         i_path = _data_path('fastqreader_min-line3')
-        reader = fastqReader(path=i_path)
-        rvals = [rval for rval in reader]
+        with fastqReader(path=i_path) as reader:
+            rvals = [rval for rval in reader]
 
         expected_reads = 2
         expected_seqs = 'ACGTACGTAC', 'CATGCATGCA'
@@ -131,29 +131,27 @@ class FastqReaderTestCase(unittest.TestCase):
 
     def test_invalid_line3(self):
         i_path = _data_path('fastqreader_min_invalid-line3')
-        reader = fastqReader(path=i_path)
-
-        with self.assertRaises(fastqFormatError):
-            for _ in reader:
-                pass
+        with fastqReader(path=i_path) as reader:
+            with self.assertRaises(fastqFormatError):
+                for _ in reader:
+                    pass
 
     def test_file_closed_on_line3_error(self):
-       i_path = _data_path('fastqreader_min_invalid-line3')
-       fh = open(i_path)
-       reader = fastqReader(fh)
-
-       with self.assertRaises(fastqFormatError):
-           for _ in reader:
-               pass
-       self.assertTrue(
-           fh.closed, 
-           'File should be closed if exception occurs due to invalid line3')
+        i_path = _data_path('fastqreader_min_invalid-line3')
+        fh = open(i_path)
+        with fastqReader(fh) as reader:
+            with self.assertRaises(fastqFormatError):
+                for _ in reader:
+                    pass
+        self.assertTrue(
+            fh.closed,
+            'File should be closed if exception occurs due to invalid line3')
 
     def test_invalid_line3_stripped(self):
         i_path = _data_path('fastqreader_min_invalid-line3')
         # fix_id=True: fix inconsistent identifiers (source: SRA data dumps)k
-        reader = fastqReader(path=i_path, fix_id=True)
-        rvals = [rval for rval in reader]
+        with fastqReader(path=i_path, fix_id=True) as reader:
+            rvals = [rval for rval in reader]
 
         expected_reads = 2
         expected_seqs = 'ACGTACGTAC', 'CATGCATGCA'

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -25,12 +25,12 @@ TEST_DIR = os.path.dirname(__file__)
 TEST_DATA_DIR = TEST_DIR
 
 
-# This test is diabled for an intermediate commit that does not include the new fix_id option.
-# It should be enabled (possibly, modified) in the following commit.
-#def test_fastq_groomer_fix_inconsistent_id():
-#    i_path = _data_path('test_data/fastqreader_min_invalid-line3')
-#    with _new_argv([i_path, "sanger", "output", "sanger", 'ascii', 'summarize_input', 'fix_id']):
-#        fastq_groomer.main()
+def test_fastq_groomer_fix_inconsistent_id():
+    i_path = _data_path('test_data/fastqreader_min_invalid-line3')
+    o_path = _data_path('test_data/fastqreader_min_invalid-line3_fixed')
+    with _new_argv([i_path, "sanger", "output", "sanger", 'ascii', 'summarize_input', '--fix_id']):
+        fastq_groomer.main()
+        _assert_paths_equal("output", o_path)
 
 
 def test_fasta_reader_cleanup():

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -25,11 +25,12 @@ TEST_DIR = os.path.dirname(__file__)
 TEST_DATA_DIR = TEST_DIR
 
 
-def test_fastq_groomer_fix_inconsistent_id():
-    #TODO add more/better tests for groomer
-    i_path = _data_path('test_data/fastqreader_min_invalid-line3')
-    with _new_argv([i_path, "sanger", "output", "sanger", 'ascii', 'summarize_input', 'fix_id']):
-        fastq_groomer.main()
+# This test is diabled for an intermediate commit that does not include the new fix_id option.
+# It should be enabled (possibly, modified) in the following commit.
+#def test_fastq_groomer_fix_inconsistent_id():
+#    i_path = _data_path('test_data/fastqreader_min_invalid-line3')
+#    with _new_argv([i_path, "sanger", "output", "sanger", 'ascii', 'summarize_input', 'fix_id']):
+#        fastq_groomer.main()
 
 
 def test_fasta_reader_cleanup():
@@ -213,7 +214,3 @@ class _TempDirectoryContext(object):
     def __exit__(self, type, value, tb):
         shutil.rmtree(self.temp_directory)
 
-
-
-if __name__ == '__main__':
-    test_fastq_groomer_inconsistent_id()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -107,8 +107,7 @@ class FastqGroomerTestCase(unittest.TestCase):
 
         with _new_argv([i_path, "sanger", "output", "sanger", 'ascii', 'summarize_input', '--no-fix-id']):
             with self.assertRaises(fastqFormatError):
-                g = Groomer()
-                g.set_file_handle(fh)
+                g = Groomer(fh)
                 g.run()
 
         self.assertTrue(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -129,9 +129,9 @@ def test_fastq_reader_cleanup():
     i_path = _data_path("sanger_full_range_original_sanger.fastqsanger")
     fh = open(i_path)
     with _new_argv([fh]):
-        reader = fastqReader(fh)
-        for _ in reader:
-            pass
+        with fastqReader(fh) as reader:
+            for _ in reader:
+                pass
     assert(fh.closed)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # TODO: implement doc linting
 [tox]
-envlist = py34-lint, py27-lint, py27-lint-readme, py27, py34, py27-lint-docstrings, tool-tests
+envlist = py35-lint, py27-lint, py27-lint-readme, py27, py35, py27-lint-docstrings, tool-tests
 python_paths = galaxy_utils scripts setup.py tests
 
 [testenv]
@@ -16,7 +16,7 @@ deps =
      flake8
      flake8-import-order
 
-[testenv:py34-lint]
+[testenv:py35-lint]
 commands = flake8 python_paths
 skip_install = True
 deps = flake8


### PR DESCRIPTION
This is the final (so far) version. The fix_id option is implemented in the groomer script, underlying library, and the tool wrapper (tools_devteam repo) (addresses this: https://github.com/galaxyproject/galaxy-hub/issues/216#issuecomment-488310228 )

The added tests should cover all reasonable cases (9dcc3dd was a surprise, I'm glad the new tests caught it). 

fastq_paired_end_deinterlacer.py is functional, but not in final form.

(once the deinterlacing option is added to groomer, the package version can be updated; I believe 1.2.0 is appropriate considering the changes?)

@jmchilton @jennaj @blankenberg 
