### PR TITLE
Fix fastqreader

### DIFF
--- a/galaxy_utils/sequence/fastq.py
+++ b/galaxy_utils/sequence/fastq.py
@@ -577,7 +577,7 @@ class fileHandler(object):
         self._file = fh
 
     def __enter__(self):
-        fh = _fastq_open_stream(fh=self.fh, format=self.format, path=self.path)
+        fh = _fastq_open_stream(fh=self.fh, format=self.format, path=self.path, mode=self.mode)
         self._set_file_handle(fh)
         return self
 

--- a/galaxy_utils/sequence/fastq.py
+++ b/galaxy_utils/sequence/fastq.py
@@ -544,41 +544,32 @@ class fastqAggregator(object):
         return column_stats
 
 
-def _fastq_open_stream(fh=None, format="sanger", path=None):
+def _fastq_open_stream(fh=None, format="sanger", path=None, mode="r"):
     if fh is None:
         assert path is not None
         if format.endswith(".gz"):
-            fh = gzip.open(path, mode="rt")
+            fh = gzip.open(path, mode="%st" % mode)
         elif format.endswith(".bz2"):
             if six.PY3:
-                fh = bz2.open(path, mode="rt")
+                fh = bz2.open(path, mode="%st" % mode)
             else:
-                fh = bz2.BZ2File(path, mode="r")
+                fh = bz2.BZ2File(path, mode=mode)
         else:
-            fh = open(path, "rt")
+            fh = open(path, "%st" % mode)
     else:
         if format.endswith(".gz"):
-            fh = gzip.GzipFile(fileobj=fh, mode="r")
+            fh = gzip.GzipFile(fileobj=fh, mode=mode)
         elif format.endswith(".bz2"):
             raise Exception("bz2 formats do not support file handle inputs")
     return fh
 
 
-class fastqReader(Iterator):
-
-    def __init__(
-            self, fh=None, format='sanger', apply_galaxy_conventions=False, path=None, fix_id=False):
-        self.fh = fh
-        self.format = format
-        self.apply_galaxy_conventions = apply_galaxy_conventions
-        self.path = path
-        self.fix_id = fix_id  # fix inconsistent identifiers (source: SRA data dumps)
-        self._file = None
+class fileHandler(object):
 
     @property
     def file(self):
         if self._file is None:
-            self._file = fastq_open_stream(fh=self.fh, format=self.format, path=self.path)
+            self._file = _fastq_open_stream(fh=self.fh, format=self.format, path=self.path, mode=self.mode)
         return self._file
 
     @file.setter
@@ -591,7 +582,7 @@ class fastqReader(Iterator):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.file.close()
+        self.close()
 
     def _set_file_handle(self, fh):
         # Extension point for subclasses to wrap file handler
@@ -603,6 +594,20 @@ class fastqReader(Iterator):
     def _close_on_error(self):
         # Extension point for subclasses (fastqVerboseErrorReader needs file access after error)
         return self.close()
+
+
+class fastqReader(Iterator, fileHandler):
+
+    mode = 'r'
+
+    def __init__(
+            self, fh=None, format='sanger', apply_galaxy_conventions=False, path=None, fix_id=False):
+        self.fh = fh
+        self.format = format
+        self.apply_galaxy_conventions = apply_galaxy_conventions
+        self.path = path
+        self.fix_id = fix_id  # fix inconsistent identifiers (source: SRA data dumps)
+        self._file = None
 
     def __next__(self):
         rval = fastqSequencingRead.get_class_by_format(self.format)()
@@ -798,44 +803,21 @@ class fastqNamedReader(fastqReader):
         return rval
 
 
-class fastqWriter(object):
+class fastqWriter(fileHandler):
+
+    mode = 'w'
 
     def __init__(self, fh=None, format=None, force_quality_encoding=None, path=None):
         self.fh = fh
         self.format = format
         self.force_quality_encoding = force_quality_encoding
         self.path = path
-
-    def __enter__(self):
-        if self.fh is None:
-            if self.format and self.format.endswith(".gz"):
-                self.fh = gzip.open(self.path, "wt")
-            elif self.format and self.format.endswith(".bz2"):
-                if six.PY2:
-                    self.fh = bz2.BZ2File(self.path, mode="w")
-                else:
-                    self.fh = bz2.open(self.path, mode="wt")
-            else:
-                self.fh = open(self.path, "wt")
-        else:
-            if self.format and self.format.endswith(".gz"):
-                self.fh = gzip.GzipFile(fileobj=self.fh)
-            elif self.format and self.format.endswith(".bz2"):
-                raise Exception("bz2 formats do not support file handle inputs")
-
-        self.file = self.fh
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
+        self._file = None
 
     def write(self, fastq_read):
         if self.format:
             fastq_read = fastq_read.convert_read_to_format(self.format, force_quality_encoding=self.force_quality_encoding)
         self.file.write(str(fastq_read))
-
-    def close(self):
-        return self.file.close()
 
 
 class fastqJoiner(object):

--- a/galaxy_utils/sequence/fastq.py
+++ b/galaxy_utils/sequence/fastq.py
@@ -573,6 +573,17 @@ class fastqReader(Iterator):
         self.apply_galaxy_conventions = apply_galaxy_conventions
         self.path = path
         self.fix_id = fix_id  # fix inconsistent identifiers (source: SRA data dumps)
+        self._file = None
+
+    @property
+    def file(self):
+        if self._file is None:
+            self._file = fastq_open_stream(fh=self.fh, format=self.format, path=self.path)
+        return self._file
+
+    @file.setter
+    def file(self, fh):
+        self._file = fh
 
     def __enter__(self):
         fh = _fastq_open_stream(fh=self.fh, format=self.format, path=self.path)

--- a/galaxy_utils/sequence/fastq.py
+++ b/galaxy_utils/sequence/fastq.py
@@ -566,6 +566,12 @@ def _fastq_open_stream(fh=None, format="sanger", path=None, mode="r"):
 
 class fileHandler(object):
 
+    def __init__(self, fh, format, path):
+        self.fh = fh
+        self.format = format
+        self.path = path
+        self._file = None
+
     @property
     def file(self):
         if self._file is None:
@@ -602,12 +608,9 @@ class fastqReader(fileHandler, Iterator):
 
     def __init__(
             self, fh=None, format='sanger', apply_galaxy_conventions=False, path=None, fix_id=False):
-        self.fh = fh
-        self.format = format
+        super(fastqReader, self).__init__(fh=fh, format=format, path=path)
         self.apply_galaxy_conventions = apply_galaxy_conventions
-        self.path = path
         self.fix_id = fix_id  # fix inconsistent identifiers (source: SRA data dumps)
-        self._file = None
 
     def __next__(self):
         rval = fastqSequencingRead.get_class_by_format(self.format)()
@@ -808,11 +811,8 @@ class fastqWriter(fileHandler):
     mode = 'w'
 
     def __init__(self, fh=None, format=None, force_quality_encoding=None, path=None):
-        self.fh = fh
-        self.format = format
+        super(fastqWriter, self).__init__(fh=fh, format=format, path=path)
         self.force_quality_encoding = force_quality_encoding
-        self.path = path
-        self._file = None
 
     def write(self, fastq_read):
         if self.format:

--- a/galaxy_utils/sequence/fastq.py
+++ b/galaxy_utils/sequence/fastq.py
@@ -547,9 +547,9 @@ class fastqAggregator(object):
 def _fastq_open_stream(fh=None, format="sanger", path=None, mode="r"):
     if fh is None:
         assert path is not None
-        if format.endswith(".gz"):
+        if format and format.endswith(".gz"):
             fh = gzip.open(path, mode="%st" % mode)
-        elif format.endswith(".bz2"):
+        elif format and format.endswith(".bz2"):
             if six.PY3:
                 fh = bz2.open(path, mode="%st" % mode)
             else:
@@ -557,9 +557,9 @@ def _fastq_open_stream(fh=None, format="sanger", path=None, mode="r"):
         else:
             fh = open(path, "%st" % mode)
     else:
-        if format.endswith(".gz"):
+        if format and format.endswith(".gz"):
             fh = gzip.GzipFile(fileobj=fh, mode=mode)
-        elif format.endswith(".bz2"):
+        elif format and format.endswith(".bz2"):
             raise Exception("bz2 formats do not support file handle inputs")
     return fh
 

--- a/galaxy_utils/sequence/fastq.py
+++ b/galaxy_utils/sequence/fastq.py
@@ -596,7 +596,7 @@ class fileHandler(object):
         return self.close()
 
 
-class fastqReader(Iterator, fileHandler):
+class fastqReader(fileHandler, Iterator):
 
     mode = 'r'
 

--- a/galaxy_utils/sequence/scripts/fastq_trimmer.py
+++ b/galaxy_utils/sequence/scripts/fastq_trimmer.py
@@ -22,7 +22,7 @@ def main():
     writer = fastqWriter(path=output_filename, format=input_type)
     reader = fastqReader(path=input_filename, format=input_type)
     with writer, reader:
-        for num_reads, fastq_read in enumerate(fastqReader(path=input_filename, format=input_type)):
+        for num_reads, fastq_read in enumerate(reader):
             if percent_offsets:
                 left_column_offset = int(round(float(left_offset) / 100.0 * float(len(fastq_read))))
                 right_column_offset = int(round(float(right_offset) / 100.0 * float(len(fastq_read))))

--- a/tests/planemo_test.bash
+++ b/tests/planemo_test.bash
@@ -40,7 +40,7 @@ else
     TARGET_TOOL_DIRS=("$1")
 fi
 
-for tool_dir in $TARGET_TOOL_DIRS
+for tool_dir in ${TARGET_TOOL_DIRS[@]}
 do
     planemo test --no_conda_auto_init --no_cleanup --no_dependency_resolution "$TOOLS_DEVTEAM/$tool_dir"
 done

--- a/tests/planemo_test.bash
+++ b/tests/planemo_test.bash
@@ -24,26 +24,9 @@ PLANEMO_VIRTUAL_ENV="${PLANEMO_VIRTUAL_ENV:-$TEMP_DIR/planemo-venv}"
 virtualenv "$PLANEMO_VIRTUAL_ENV"
 . "$PLANEMO_VIRTUAL_ENV/bin/activate"
 pip install "$PLANEMO_INSTALL_TARGET"
-deactivate
-
-ENV_DIR="$TEMP_DIR/dependencies/galaxy_sequence_utils/dev"
-mkdir -p "$ENV_DIR"
-cat "$SCRIPT_DIR/planemo_test_env.sh" | sed -e "s#_temp_dir_#/$TEMP_DIR#" > "$ENV_DIR/env.sh"
-ln -s dev "$TEMP_DIR/dependencies/galaxy_sequence_utils/default"
-
-virtualenv "$ENV_DIR/venv"
-. "$ENV_DIR/venv/bin/activate"
 
 cd $SCRIPT_DIR/..
 python setup.py "$SETUP_COMMAND"
-
-## TODO: Add option to test a wheel instead.
-# pip install $SCRIPT_DIR/../dist/*whl
-
-cat "$SCRIPT_DIR/planemo_test_dependency_resolvers_conf_template.xml" | sed -e "s#_temp_dir_#$TEMP_DIR#" > "$TEMP_DIR/dependency_resolvers_conf.xml"
-
-
-. "$PLANEMO_VIRTUAL_ENV/bin/activate"
 
 if [ -z "$1" ];
 then
@@ -59,5 +42,5 @@ fi
 
 for tool_dir in $TARGET_TOOL_DIRS
 do
-    planemo test --no_cleanup --dependency_resolvers_config_file "$TEMP_DIR/dependency_resolvers_conf.xml" "$TOOLS_DEVTEAM/$tool_dir"
+    planemo test --no_conda_auto_init --no_cleanup --no_dependency_resolution "$TOOLS_DEVTEAM/$tool_dir"
 done

--- a/tests/planemo_test_dependency_resolvers_conf_template.xml
+++ b/tests/planemo_test_dependency_resolvers_conf_template.xml
@@ -1,3 +1,0 @@
-<dependency_resolvers>
-  <galaxy_packages versionless="true" base_path="_temp_dir_/dependencies" />
-</dependency_resolvers>

--- a/tests/planemo_test_env.sh
+++ b/tests/planemo_test_env.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-. "_temp_dir_/dependencies/galaxy_sequence_utils/dev/venv/bin/activate"


### PR DESCRIPTION
Fixes:
```
|  File "/usr/local/lib/python3.8/site-packages/galaxy_utils/sequence/scripts/fastq_trimmer.py", line 25, in main
|  for num_reads, fastq_read in enumerate(fastqReader(path=input_filename, format=input_type)):
|  File "/usr/local/lib/python3.8/site-packages/galaxy_utils/sequence/fastq.py", line 664, in __iter__
|  yield next(self)
|  File "/usr/local/lib/python3.8/site-packages/galaxy_utils/sequence/fastq.py", line 599, in __next__
|  id_line = self._read_fastq_header()  # We need the raw line1 to compare w/line3
|  File "/usr/local/lib/python3.8/site-packages/galaxy_utils/sequence/fastq.py", line 613, in _read_fastq_header
|  line = self.file.readline()
|  AttributeError: 'fastqReader' object has no attribute 'file'
```

Tested this manually and it fixed the remaining errors in https://github.com/galaxyproject/tools-iuc/pull/2466